### PR TITLE
Improve error printing.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn dump(state: &TockilatorState) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main_core() -> Result<(), Box<dyn Error>> {
     let matches = App::new("tockilator")
         .arg(
             Arg::with_name("elf")
@@ -85,4 +85,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     tockilator.tracefile(matches.value_of("tracefile").unwrap(), dump)?;
 
     Ok(())
+}
+
+fn main() {
+    if let Err(e) = main_core() {
+        eprintln!("Error: {}", e);
+    }
 }


### PR DESCRIPTION
Previously the runtime would print the Debug representation of any
error, which looked like this:

Error: TockilatorError { message: Some("unrecognized ELF object: /dev/null"), kind: Goblin(Scroll(BadOffset(0))) }

With this commit, the same condition prints:

Error: unrecognized ELF object: /dev/null: bad offset 0